### PR TITLE
A way to do doubleEveryOther without the flag

### DIFF
--- a/src/Week1.hs
+++ b/src/Week1.hs
@@ -16,14 +16,14 @@ toDigitsRev x
 
 -- Double every other integer in a list
 doubleEveryOther :: [Integer] -> [Integer]
-doubleEveryOther ds = reverse (doubleEveryOther' False (reverse ds))
+doubleEveryOther ds = reverse (doubleEveryOther' (reverse ds))
 
--- Inner function for doubling every other number in a list. The boolean flag is
--- whether or not to double the next number.
-doubleEveryOther' :: Bool -> [Integer] -> [Integer]
-doubleEveryOther' _     []       = []
-doubleEveryOther' True  (x : xs) = 2 * x : doubleEveryOther' False xs
-doubleEveryOther' False (x : xs) = x     : doubleEveryOther' True xs
+-- Inner function for doubling every other number in a list,
+-- starting with the second item in the list.
+doubleEveryOther' :: [Integer] -> [Integer]
+doubleEveryOther' [] = []
+doubleEveryOther' [n] = [n]
+doubleEveryOther' (n : m : t) = n : 2*m : doubleEveryOther' t
 
 validateCC :: Integer -> Bool
 validateCC n = let


### PR DESCRIPTION
In your class the other night, a couple of us mentioned that there was a way to do this with just pattern matching and no Boolean flag.

This is the way I wrote it. I use pattern matching to handle pairs of items at a time, which makes it easy to select which thing is doubled.

Since doubleEveryOther' is passed the reverse of the initial list, the first item in the list was originally the last, which is skipped, and the second item in the list is the next-to-last, which should be doubled.

So we just go down the list two at a time, until we hit either a singleton, or the empty list.

doubleEveryOther just reverses the result.

Since this is literally the first Haskell program I've ever written, I'm sure there are style issues in what I wrote. Feel free to correct these.