### PR TITLE
Fixes may 2017

### DIFF
--- a/test/Main.hs
+++ b/test/Main.hs
@@ -288,7 +288,7 @@ histogramA = "\
              \**********\n\
              \**********\n\
              \==========\n\
-             \0123456789"
+             \0123456789\n"
 
 histTestB :: TestTree
 histTestB = mkTest histogram ([0] ++ replicate 5 2 ++ [1,3,1,1,9]) histogramB
@@ -301,7 +301,7 @@ histogramB = "\
              \ **       \n\
              \****     *\n\
              \==========\n\
-             \0123456789"
+             \0123456789\n"
 
 histTestC :: TestTree
-histTestC = mkTest histogram [] "==========\n0123456789"
+histTestC = mkTest histogram [] "==========\n0123456789\n"

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -256,11 +256,11 @@ skipsTests = testGroup "skips"
 
 mkTestStr :: (Show a, Eq a) => (String -> a) -> String -> a -> TestTree
 mkTestStr f input expected = testCase input $
-  assertEqual eqTestDesc (f input) expected
+  assertEqual eqTestDesc expected (f input)
 
 mkTest :: (Show a, Show t, Eq a) => (t -> a) -> t -> a -> TestTree
 mkTest f input expected = testCase (show input) $
-  assertEqual eqTestDesc (f input) expected
+  assertEqual eqTestDesc expected (f input)
 
 eqTestDesc :: [Char]
 eqTestDesc = "output should equal expected from homework PDF"


### PR DESCRIPTION
The "got" and "expected" were reversed in equality tests - fixed that.

The histograms should have newlines at the end. The example in the problem description shows a newline at the end. It's also easy to write that way with 'unlines'.